### PR TITLE
Fix for add new item links

### DIFF
--- a/contentGeneration/public/spaArtifacts/assets/displayTemplates.js
+++ b/contentGeneration/public/spaArtifacts/assets/displayTemplates.js
@@ -596,6 +596,7 @@
                 if(ctx.ListTemplateType === SP.ListTemplateType.documentLibrary){ return; }
                 var td = webPartDiv.find("td.ms-list-addnew");
                 var newItemLink = td.find("a").eq(0);
+                newItemLink.detach();
                 td.html('');
                 td.append(newItemLink);
             }


### PR DESCRIPTION
Added a line to detach the anchor tag before blanking out the TD.  This was causing the new item links not to appear on the page